### PR TITLE
Fix WSL2 check

### DIFF
--- a/bin/kiri
+++ b/bin/kiri
@@ -1197,7 +1197,7 @@ if [[ ${ARCHIVE} == 1 ]]; then
 fi
 
 if [[ "${LAUNCH_BROWSER}" != 0 ]]; then
-	if grep -q "Microsoft" "/proc/version" &> /dev/null; then
+	if grep -i -q "Microsoft" "/proc/version" &> /dev/null; then
 		# Webserver alternative for Windows with WSL
 		host=127.0.0.1
 		if [[ "${WEBSERVER_PORT}" == "" ]]; then


### PR DESCRIPTION
On my WSL2 installation, `/proc/version` prints out `Linux version 5.4.72-microsoft-standard-WSL2 (oe-user@oe-host) (gcc version 8.2.0 (GCC)) #1 SMP Wed Oct 28 23:40:43 UTC 2020`, so i made grep case-insensitive, to be able to correctly identify my machine being a WSL machine