### PR TITLE
Update kiri-file-picker

### DIFF
--- a/bin/kiri-file-picker
+++ b/bin/kiri-file-picker
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/bin/python
 
 import pathlib
 import wx


### PR DESCRIPTION
Changed python to /usr/local/bin/python -> Fixes python3 usage via brew on OSX