### PR TITLE
tolerate base_distro check & WSL detect

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -7,7 +7,7 @@ ctrl_c()
 
 identify_linux_or_wsl()
 {
-	if uname -rv | grep -q "Microsoft"; then
+	if grep -qi microsoft /proc/version; then
 		echo "WSL"
 	else
 		echo "Linux"
@@ -28,11 +28,11 @@ identify_operating_system()
 
 identify_linux_pkg_manager()
 {
-	base_distro="$(grep ID_LIKE /etc/os-release | cut -d= -f2)"
+	base_distro="$(grep ID /etc/os-release | cut -d= -f2)"
 
 	case "${base_distro}" in
-		"debian") echo "apt"     ;;
-		"fedora") echo "yum"     ;;
+		*"debian"*) echo "apt"     ;;
+		*"fedora"*) echo "yum"     ;;
 		*)        echo "Unknown" ;;
 	esac
 }


### PR DESCRIPTION
This will not work on Debian Linux. The changed script will search for all values with ID in the key. If there is the required value in the returned string, it passes the test.
WSL detection is not working on my debian WSL. I found the answer here: https://stackoverflow.com/a/38859331/13406850. It has been applied to the function.