### PR TITLE
Fix inverted logic for checking if DISPLAY set

### DIFF
--- a/bin/kiri
+++ b/bin/kiri
@@ -641,7 +641,7 @@ launch_project_selector_gui()
 {
 	local file_path
 
-	if [[ -n ${DISPLAY} ]]; then
+	if [[ -z ${DISPLAY} ]]; then
 		export DISPLAY=:1.0
 	fi
 


### PR DESCRIPTION
I think `-n` and `-z` were mixed up here. The previous code overwrote the `DISPLAY` variable if it's already set. This update only sets a default value if `DISPLAY` is NOT already set.

From `man test`:

```
       -n STRING
              the length of STRING is nonzero
       -z STRING
              the length of STRING is zero
```