### PR TITLE
Find KIRI_HOME_PATH even if $0 is symlink

### DIFF
--- a/bin/kiri
+++ b/bin/kiri
@@ -2208,7 +2208,7 @@ main()
 	trap "exit 1" TERM
 	trap cleanup_on_exit INT
 
-	readonly KIRI_HOME_PATH="$(dirname "$(dirname "${0}")")"
+	readonly KIRI_HOME_PATH="$(dirname "$(dirname "$(readlink -f "${0}")")")"
 
 	check_required_tools
 


### PR DESCRIPTION
If `kiri` is run via a symlink, then `KIRI_HOME_PATH` will point to the directory of the symlink, not the true kiri home directory.