### PR TITLE
Add Python requirements.txt

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -215,14 +215,7 @@ macos_install_brew_modules()
 install_python_modules()
 {
 	# Kicad-Diff dependencies
-	yes | pip3 install "pillow>8.2.0"
-	yes | pip3 install "six>=1.15.0"
-	yes | pip3 install "dateutils>=0.6.12"
-	yes | pip3 install "python_dateutil>=2.8.1"
-	yes | pip3 install "pytz>=2021.1"
-	yes | pip3 install "pathlib>=1.0.1"
-	yes | pip3 install "wxpython>=4.0.7"
-	yes | pip3 install "wxwidgets>=1.0.5"
+	yes | pip3 install -r requirements.txt
 }
 
 init_opam()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+pillow>8.2.0
+six>=1.15.0
+dateutils>=0.6.12
+python_dateutil>=2.8.1
+pytz>=2021.1
+pathlib>=1.0.1
+wxpython>=4.0.7
+wxwidgets>=1.0.5


### PR DESCRIPTION
This pull request moves the list of python dependencies from `install_dependencies.sh` into `requirements.txt`.  There are a few reasons to do this:

1. With the dependencies defined outside of the install script, it's possible to install them or easily read the list of dependencies with other tools without running the install script. For example, the reason I am making this PR is that in the `PKGBUILD` for the Arch User Repository package I maintain, I can just do `pip install -r requirements.txt`. Currently, I have pretty much the same [8 `pip install` lines that you have in `install_dependencies.sh`](https://github.com/leoheck/kiri/blob/main/install_dependencies.sh#L221-L228). If these lines are changed in kiri without my noticing, the AUR package would break.
2. Having a `requirements.txt` file (or `setup.py` file) is the Python standard
3. It should be faster to only invoke pip once with the full list of dependencies