### PR TITLE
kiri: Add --no-error-on-commit-count

### DIFF
--- a/bin/kiri
+++ b/bin/kiri
@@ -383,6 +383,7 @@ export START_ON_LAYOUT_VIEW=0
 export START_SERVER=1
 export VERBOSE=0
 export SKIP_KICAD_6=0
+export NO_ERROR_ON_COMMIT_COUNT=0
 
 export NEWER_COMMIT
 export OLDER_COMMIT
@@ -547,36 +548,38 @@ show_help()
 
 	OPTIONS:
 
-	     ls               List project commits with Kiri style
+	     ls                         List project commits with Kiri style
 
-	     -a|--all         Include all commits even if schematics/layout don't have changes
-	     -o|--older HASH  Show commits starting from this one
-	     -n|--newer HASH  Show commits until this one delimited by this one
-	     -t|--last VAL    Show last N commits
+	     -a|--all                   Include all commits even if schematics/layout don't have changes
+	     -o|--older HASH            Show commits starting from this one
+	     -n|--newer HASH            Show commits until this one delimited by this one
+	     -t|--last VAL              Show last N commits
 
-	     -l|--no-server   Do not launch webserver/browser at the end
-	     -S|--server-only Start webserver but not launch browser
-	     -p|--port PORT   Set webserver port. By default it will try to use an available port.
-	     -i|--ip ADDR     Override the default 127.0.0.1 IP address
+	     -l|--no-server             Do not launch webserver/browser at the end
+	     -S|--server-only           Start webserver but not launch browser
+	     -p|--port PORT             Set webserver port. By default it will try to use an available port.
+	     -i|--ip ADDR               Override the default 127.0.0.1 IP address
 
-	     -s|--skip-cache  Skip usage of -chache.lib on plotgitsch
-	     -6|--skip-kicad6 Skip ploting Kicad 6 schematics (.kicad.sch)
-	     -u|--layout      Force starting with the Layout view selected
-	     -f|--page-frame  Disable page frame for PCB
+	     -s|--skip-cache            Skip usage of -chache.lib on plotgitsch
+	     -6|--skip-kicad6           Skip ploting Kicad 6 schematics (.kicad.sch)
+	     -u|--layout                Force starting with the Layout view selected
+	     -f|--page-frame            Disable page frame for PCB
 
-	     -d|--output-dir  Change output folder path/name
-	     -r|--remove      Remove generated folder before running it
-	     -x|--archive     Archive generate files
+	     -d|--output-dir            Change output folder path/name
+	     -r|--remove                Remove generated folder before running it
+	     -x|--archive               Archive generate files
 
-	     -v|--version     Show version
-	     -h|--help        Show help
+	     --no-error-on-commit-count Don't error when the commit count is < 2
 
-	     -X|--super-debug Tons of things
-	     -D|--debug       Extra info
-	    -dp|--debug-sch   Show Plotgitsch stdout and stderr
-	    -dk|--debug-pcb   Show Kidiff stdout and stderr
-	     -y|--dry-run     Run without generate artifacts
-	     -V|--verbose     Verbose
+	     -v|--version               Show version
+	     -h|--help                  Show help
+
+	     -X|--super-debug           Tons of things
+	     -D|--debug                 Extra info
+	    -dp|--debug-sch             Show Plotgitsch stdout and stderr
+	    -dk|--debug-pcb             Show Kidiff stdout and stderr
+	     -y|--dry-run               Run without generate artifacts
+	     -V|--verbose               Verbose
 
 	KICAD_PROJECT_FILE:
 
@@ -807,6 +810,11 @@ command_line_parse()
 			-i|--ip)
 				IP_ADDRESS="${2}"
 				shift 2
+				;;
+
+			--no-error-on-commit-count)
+				NO_ERROR_ON_COMMIT_COUNT=1
+				shift
 				;;
 
 			ls)
@@ -1121,7 +1129,11 @@ get_git_commits_list()
 	# Commits list has to have 2 commits at least
 	if [[ $(echo "${COMMITS}" | wc -l ) -lt 2 ]]; then
 		echo "Leaving, less than 2 commits found"
-		exit 1
+		if [[ "${NO_ERROR_ON_COMMIT_COUNT}" == "0" ]]; then
+			exit 1
+		else
+			exit 0
+		fi
 	fi
 
 	if [[ "${VERBOSE}" == "1" ]] || [[ "${DEBUG}" == "1" ]]; then


### PR DESCRIPTION
If ran in a CI pipeline, the check for commit count fails the pipeline with `Leaving, less than 2 commits found`.

This adds an option to change the exit code of this check to 0 for use in CI pipelines that might run this without checking first if there are enough commits in the pull request.

`--no-error-on-commit-count` might not be the most appropriate flag name, this can of course be changed.

This is part of a GitHub Action to run Kiri. I'm not planning on publishing this to the Actions marketplace or anything, just using this for a personal project: https://github.com/USA-RedDragon/kiri-github-action.