### PR TITLE
kiri.js: Load favicon.ico at a relative path

### DIFF
--- a/assets/kiri.js
+++ b/assets/kiri.js
@@ -1161,7 +1161,7 @@ function check_server_status()
         server_is_offline();
     };
 
-    img.src = "/web/favicon.ico" + url_timestamp();
+    img.src = "favicon.ico" + url_timestamp();
 
     setTimeout(check_server_status, 5000);
 }


### PR DESCRIPTION
This fixes the server status when the output files are served from a subdirectory

Relates #85 for GitHub Actions fixes