### PR TITLE
Provide a path to python-requirements.txt w/ installing Python deps

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -219,7 +219,11 @@ install_python_modules()
 	# source venv/bin/activate
 
 	# Kicad-Diff dependencies
-	yes | pip3 install -r python-requirements.txt
+	if [[ ! -z "${KIRI_HOME}" && -f "${KIRI_HOME}/python-requirements.txt" ]]; then
+		yes | pip3 install -r "${KIRI_HOME}/python-requirements.txt"
+	else
+		yes | pip3 install -r https://raw.githubusercontent.com/leoheck/kiri/main/python-requirements.txt
+	fi
 }
 
 init_opam()


### PR DESCRIPTION
This PR is a fix to #100.

When installing Python modules, this PR adds a verification to the process:

* If `${KIRI_HOME}` is set and if `${KIRI_HOME}/python-requirements.txt` exists, we install Python modules from the local `python-requirements.txt` file.
* Else, we install the modules that are listed in the raw `python-requirements.txt` file on the GitHub repo

Before merging, I would check with @MarcelRobitaille, as this fix may hinder on the build process for the AUR package he maintains, as per #82. 
