### PR TITLE
Add support for git lfs files

### DIFF
--- a/bin/kiri
+++ b/bin/kiri
@@ -1412,6 +1412,18 @@ export_project_files()
 	else
 		mkdir -p "${OUTPUT_DIR_PATH}/${commit_hash}"
 		git archive --format=tar ${commit_hash} | (cd "${OUTPUT_DIR_PATH}/${commit_hash}" && tar xf -)
+
+		# Convert lfs pointers to actual files
+		cd "${OUTPUT_DIR_PATH}/${commit_hash}"
+		for file in *
+		do
+			git check-attr -a $file | grep "filter: lfs" > /dev/null
+			if [ $? -eq 0 ]; then
+				cat $file > tmp; cat tmp | git lfs smudge > $file
+			fi
+		done
+		rm -f tmp
+		cd - > /dev/null
 	fi
 }
 


### PR DESCRIPTION
When kicad files are stored in a git repo as lfs files 'git archive' command stores only pointers.
'git archive' can't handle lfs files so after they are stored they need to be processed by
'git lfs smudge' command to get actual files.

This PR goes over all archived files and checks if they are lfs pointers.
It runs `git lfs smudge` command on each pointer file.

I'm not a git expert so if there is a better approach, I'm happy to fix it.